### PR TITLE
Average out appearance of long duration lines

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -111,7 +111,8 @@ const Shotter = {
 			return this.playersText.split(/\r?\n/)
 		},
 		currentLine : function(){
-			let lineIndex = this.lines.findIndex(line=>line.timeEpoch.from >= this.playstate.position)
+			let averageEpoch = line => 0.5*(line.timeEpoch.to+line.timeEpoch.from)
+			let lineIndex = this.lines.findIndex(line=> averageEpoch(line) >= this.playstate.position)
 			//This finds the next line, so really we need to find the previous one, and account
 			//For end effects
 			if (lineIndex != 0) {


### PR DESCRIPTION
Some lines are on screen for a long time 

We could trigger when the line starts:
`line.timeEpoch.from`
When the line finishes:
`line.timeEpoch.to`
Or ... on average... that's what I'm trying here